### PR TITLE
Feat/SleepResumeCallback

### DIFF
--- a/ContribSentry.SessionTest/Cache/EnvelopeCacheTests.cs
+++ b/ContribSentry.SessionTest/Cache/EnvelopeCacheTests.cs
@@ -1,0 +1,59 @@
+﻿using ContribSentry.Cache;
+using ContribSentry.Enums;
+using ContribSentry.Testing;
+using Sentry.Protocol;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace ContribSentry.SessionTest.Cache
+{
+    public class EnvelopeCacheTests
+    {
+        [Fact]
+        public void Store_CurrentSession_Saves_In_File()
+        {
+            using (var folder = new TempFolder())
+            {
+                var envelopeCache = new EnvelopeCache(new ContribSentryOptions(cacheEnable: true)
+                {
+                    CacheDirPath = folder.FolderName
+                });
+                var bytes = new byte[3] { 1, 2, 3 };
+                var cachedData = new CachedSentryData(SentryId.Empty, bytes, ESentryType.CurrentSession);
+                envelopeCache.Store(cachedData);
+                Assert.True(File.Exists($"{folder.FolderName}/session"));
+                envelopeCache.Discard(cachedData);
+                Assert.False(File.Exists($"{folder.FolderName}/session"));
+            }
+        }
+
+
+        [Fact]
+        public void Iterator_Return_CurrentSession_If_Previously_Stored()
+        {
+            using (var folder = new TempFolder())
+            {
+                var envelopeCache = new EnvelopeCache(new ContribSentryOptions(cacheEnable: true)
+                {
+                    CacheDirPath = folder.FolderName
+                }); ;
+                var bytes = new byte[3] { 1, 2, 3 };
+                var cachedData = new CachedSentryData(SentryId.Empty, bytes, ESentryType.CurrentSession);
+                envelopeCache.Store(cachedData);
+                Assert.True(File.Exists($"{folder.FolderName}/session"));
+
+                var retreivedCachedList = envelopeCache.Iterator();
+                Assert.Single(retreivedCachedList);
+                Assert.Equal(bytes, retreivedCachedList[0].Data);
+
+                foreach (var data in retreivedCachedList)
+                {
+                    envelopeCache.Discard(data);
+                    Assert.False(File.Exists(envelopeCache.GetEnvelopePath(data)));
+                }
+            }
+        }
+    }
+}

--- a/ContribSentry.SessionTest/ContribSentry.SessionTest.csproj
+++ b/ContribSentry.SessionTest/ContribSentry.SessionTest.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ContribSentry.Testing\ContribSentry.Testing.csproj" />
     <ProjectReference Include="..\ContribSentry\ContribSentry.csproj" />
   </ItemGroup>
 

--- a/ContribSentry.SessionTest/Initializer.cs
+++ b/ContribSentry.SessionTest/Initializer.cs
@@ -16,7 +16,7 @@ namespace SessionSdk.Test
             if (!ContribSentrySdk.IsEnabled)
             {
                 var integration = new ContribSentrySdkIntegration(new ContribSentryOptions() { GlobalSessionMode = true });
-                integration.Register(null, new SentryOptions() { Release = TestRelease, Environment = TestEnvironment, Dsn = new Dsn(DsnHelper.ValidDsnWithoutSecret) });
+                integration.Register(null, new SentryOptions() { Release = TestRelease, Environment = TestEnvironment, Dsn = new Dsn(Helpers.DsnHelper.ValidDsnWithoutSecret) });
             }
         }
     }

--- a/ContribSentry.SessionTest/Internals/SentryEnvelopeTest.cs
+++ b/ContribSentry.SessionTest/Internals/SentryEnvelopeTest.cs
@@ -1,6 +1,7 @@
 ﻿using ContribSentry.Enums;
 using ContribSentry.Internals;
 using Sentry.Protocol;
+using System.IO;
 using Xunit;
 
 namespace ContribSentry.SessionTest.Internals
@@ -18,6 +19,26 @@ namespace ContribSentry.SessionTest.Internals
             Assert.Equal(sdk, envelope.Header.SdkVersion);
             Assert.Equal(ESentryType.Session , envelope.Items[0].Type.Type);
             Assert.NotNull(envelope.Items[0].Data);
+        }
+
+        [Fact]
+        public void New_CurrentSession_Creates_Envelope_With_EventyId_Empty_And_EnvelopeItem_As_Session()
+        {
+            var session = new Session("2", new User() { Id = "1" }, "e", "r");
+            var sdk = new SdkVersion() { Name = "a", Version = "c" };
+            var serializer = new Serializer();
+
+            var memStream = new MemoryStream();
+            serializer.Serialize(session, memStream);
+            var sessionSerialized = memStream.ToArray();
+            memStream.Flush();
+
+            var envelope = SentryEnvelope.FromSession(sessionSerialized, sdk);
+
+            Assert.Equal(SentryId.Empty, envelope.Header.EventId);
+            Assert.Equal(sdk, envelope.Header.SdkVersion);
+            Assert.Equal(ESentryType.Session, envelope.Items[0].Type.Type);
+            Assert.Equal(sessionSerialized,envelope.Items[0].Data);
         }
     }
 }

--- a/ContribSentry.Test/Mock/MockSessionService.cs
+++ b/ContribSentry.Test/Mock/MockSessionService.cs
@@ -6,13 +6,13 @@ namespace ContribSentry.Test.Mock
 {
     public class MockSessionService : IContribSentrySessionService
     {
-        public void Close() { }
-
-        public void EndSession() { }
-        public ISession GetCurrent() => DisabledSession.Instance;
 
         public void Init(ContribSentryOptions options, IEndConsumerService endConsumer) { }
-
+        public void Close() { }
+        public ISession GetCurrent() => DisabledSession.Instance;
         public void StartSession(User user, string distinctId, string environment, string release) { }
+        public void EndSession() { }
+        public void DeleteCachedCurrentSession() { }
+        public void CacheCurrentSesion() { }
     }
 }

--- a/ContribSentry/ContribSentry.csproj
+++ b/ContribSentry/ContribSentry.csproj
@@ -14,7 +14,7 @@
     <PackageId>ContribSentry</PackageId>
     <Product>ContribSentry.SessionSdk</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ContribSentry/ContribSentrySdk.cs
+++ b/ContribSentry/ContribSentrySdk.cs
@@ -69,6 +69,22 @@ namespace ContribSentry
         }
 
         /// <summary>
+        /// Backup the current data (Clientside apps)
+        /// </summary>
+        public static void Sleep()
+        {
+            SessionService.CacheCurrentSesion();
+        }
+
+        /// <summary>
+        /// Inform that your application was resumed (Clientside apps)
+        /// </summary>
+        public static void Resume()
+        {
+            SessionService.DeleteCachedCurrentSession();
+        }
+
+        /// <summary>
         /// Clears the project Data.
         /// </summary>
         public static void Close()

--- a/ContribSentry/Enums/ESentryType.cs
+++ b/ContribSentry/Enums/ESentryType.cs
@@ -6,6 +6,7 @@
         Event,
         Attachment,
         Transaction,
-        Unknown
+        Unknown,
+        CurrentSession
     }
 }

--- a/ContribSentry/Extensibility/DisabledSessionService.cs
+++ b/ContribSentry/Extensibility/DisabledSessionService.cs
@@ -6,14 +6,19 @@ namespace ContribSentry.Extensibility
     internal class DisabledSessionService : IContribSentrySessionService
     {
         internal static DisabledSessionService Instance = new DisabledSessionService();
-        public void Close() { }
-
-        public void EndSession() { }
-
-        public ISession GetCurrent() => DisabledSession.Instance;
 
         public void Init(ContribSentryOptions options, IEndConsumerService endConsumer) { }
 
+        public void Close() { }
+
+        public ISession GetCurrent() => DisabledSession.Instance;
+
         public void StartSession(User user, string distinctId, string environment, string release) { }
+
+        public void EndSession() { }
+
+        public void CacheCurrentSesion() { }
+
+        public void DeleteCachedCurrentSession() { }
     }
 }

--- a/ContribSentry/Interface/IContribSentrySessionService.cs
+++ b/ContribSentry/Interface/IContribSentrySessionService.cs
@@ -34,6 +34,10 @@ namespace ContribSentry.Interface
         /// <param name="release">The release</param>
         void EndSession();
 
+        void CacheCurrentSesion();
+
+        void DeleteCachedCurrentSession();
+
         /// <summary>
         /// Used internally.
         /// </summary>

--- a/ContribSentry/Interface/IEndConsumerService.cs
+++ b/ContribSentry/Interface/IEndConsumerService.cs
@@ -10,6 +10,7 @@ namespace ContribSentry.Interface
     {
         void CaptureTracing(SentryTracingEvent tracing);
         void CaptureSession(ISession session);
+        void CacheCurrentSession(ISession session);
         Task<bool> CaptureCachedEnvelope(CachedSentryData envelope);
     }
 }

--- a/ContribSentry/Internals/ContribSentrySessionService.cs
+++ b/ContribSentry/Internals/ContribSentrySessionService.cs
@@ -69,7 +69,7 @@ namespace ContribSentry.Internals
                 if(GetCurrent() is Session session)
                 {
                     var cached = session.Clone();
-                    cached.End();
+                    cached.End(DateTime.UtcNow);
                     EndConsumer.CacheCurrentSession(cached);
                 }
             }

--- a/ContribSentry/Internals/SentryEnvelope.cs
+++ b/ContribSentry/Internals/SentryEnvelope.cs
@@ -37,6 +37,11 @@ namespace ContribSentry.Internals
             return new SentryEnvelope(SentryId.Empty, sdkVersion, SentryEnvelopeItem.FromSession(session, serializer));
         }
 
+        public static SentryEnvelope FromSession(byte[] session, SdkVersion sdkVersion)
+        {
+            return new SentryEnvelope(SentryId.Empty, sdkVersion, SentryEnvelopeItem.FromSession(session));
+        }
+
         public static SentryEnvelope FromTracing(SentryTracingEvent tracing, SdkVersion sdkVersion,
             Serializer serializer)
         {

--- a/ContribSentry/Internals/SentryEnvelopeItem.cs
+++ b/ContribSentry/Internals/SentryEnvelopeItem.cs
@@ -24,6 +24,11 @@ namespace ContribSentry.Internals
             return new SentryEnvelopeItem(new SentryItemType(ESentryType.Session), array);
         }
 
+        public static SentryEnvelopeItem FromSession(byte[] session)
+        {
+            return new SentryEnvelopeItem(new SentryItemType(ESentryType.Session), session);
+        }
+
         public static SentryEnvelopeItem FromTransaction(SentryTracingEvent tracing, Serializer serializer)
         {
             var memoryStream = new MemoryStream();

--- a/ContribSentry/Internals/Session.cs
+++ b/ContribSentry/Internals/Session.cs
@@ -135,14 +135,7 @@ namespace ContribSentry.Internals
                     Status = ESessionState.Exited;
                 }
 
-                if (timestamp != null)
-                {
-                    Timestamp = timestamp;
-                }
-                else
-                {
-                    Timestamp = DateTime.UtcNow;
-                }
+                Timestamp = timestamp ?? DateTime.UtcNow;
 
                 if (timestamp != null)
                 {


### PR DESCRIPTION
This PR Adds two functions to ContribSentrySDK mostly focused on applications where only one user interact.

-Sleep()
-Resume()

Those functions indicate to the SDK that the user is leaving and going back to the Application, allowing to cache certain things like the current session in case you leave the app and forgets to End the current session.

This function is not according to Sentry's SDK pattern but it works does the job.