### PR TITLE
Hot/wrong enum values in mono

### DIFF
--- a/ContribSentry/ContribSentry.csproj
+++ b/ContribSentry/ContribSentry.csproj
@@ -14,7 +14,7 @@
     <PackageId>ContribSentry</PackageId>
     <Product>ContribSentry.SessionSdk</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>3.1.3</Version>
+    <Version>3.1.4</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ContribSentry/Enums/ESentryType.cs
+++ b/ContribSentry/Enums/ESentryType.cs
@@ -1,12 +1,25 @@
-﻿namespace ContribSentry.Enums
+﻿using System.Runtime.Serialization;
+
+namespace ContribSentry.Enums
 {
     public enum ESentryType
     {
+        [EnumMember(Value = "session")]
         Session,
+
+        [EnumMember(Value = "event")]
         Event,
+
+        [EnumMember(Value = "attachment")]
         Attachment,
+
+        [EnumMember(Value = "attachment")]
         Transaction,
+
+        [EnumMember(Value = "unknown")]
         Unknown,
+
+        [EnumMember(Value = "currentSession")]
         CurrentSession
     }
 }

--- a/ContribSentry/Enums/ESessionState.cs
+++ b/ContribSentry/Enums/ESessionState.cs
@@ -1,10 +1,19 @@
-﻿namespace ContribSentry.Enums
+﻿using System.Runtime.Serialization;
+
+namespace ContribSentry.Enums
 {
     public enum ESessionState
     {
+        [EnumMember(Value = "ok")]
         Ok,
+
+        [EnumMember(Value = "exited")]
         Exited,
+
+        [EnumMember(Value = "crashed")]
         Crashed,
+
+        [EnumMember(Value = "abnormal")]
         Abnormal // not currently used in this SDK.
     }
 }

--- a/ContribSentry/Enums/ESpanRequest.cs
+++ b/ContribSentry/Enums/ESpanRequest.cs
@@ -1,11 +1,22 @@
-﻿namespace ContribSentry.Enums
+﻿using System.Runtime.Serialization;
+
+namespace ContribSentry.Enums
 {
     public enum ESpanRequest
     {
+        [EnumMember(Value = "get")]
         Get,
+
+        [EnumMember(Value = "post")]
         Post,
+
+        [EnumMember(Value = "put")]
         Put,
+
+        [EnumMember(Value = "delete")]
         Delete,
+
+        [EnumMember(Value = "patch")]
         Patch
     }
 }

--- a/ContribSentry/Enums/ESpanStatus.cs
+++ b/ContribSentry/Enums/ESpanStatus.cs
@@ -1,4 +1,6 @@
-﻿namespace ContribSentry.Enums
+﻿using System.Runtime.Serialization;
+
+namespace ContribSentry.Enums
 {
 
     /// <summary>
@@ -8,38 +10,71 @@
     internal enum ESpanStatus
     {
         /// <summary>The operation completed successfully.</summary>
+        [EnumMember(Value = "ok")]
         Ok,
+
         /// <summary>Deadline expired before operation could complete.</summary>
+        [EnumMember(Value = "deadlineExceeded")]
         DeadlineExceeded,
+
         /// <summary>401 Unauthorized (actually does mean unauthenticated according to RFC 7235).</summary>
+        [EnumMember(Value = "unauthenticated")]
         Unauthenticated,
+
         /// <summary>403 Forbidden</summary>
+        [EnumMember(Value = "permissionDenied")]
         PermissionDenied,
+
         /// <summary>404 Not Found. Some requested entity (file or directory) was not found.</summary>
+        [EnumMember(Value = "notFound")]
         NotFound,
+
         /// <summary>429 Too Many Requests</summary>
+        [EnumMember(Value = "resourceExhausted")]
         ResourceExhausted,
+
         /// <summary>Client specified an invalid argument. 4xx.</summary>
+        [EnumMember(Value = "invalidArgument")]
         InvalidArgument,
+
         /// <summary>501 Not Implemented</summary>
+        [EnumMember(Value = "unimplemented")]
         Unimplemented,
+
         /// <summary>503 Service Unavailable</summary>
+        [EnumMember(Value = "unavailable")]
         Unavailable,
+
         /// <summary>Other/generic 5xx.</summary>
+        [EnumMember(Value = "internalError")]
         InternalError,
+
         /// <summary>Unknown. Any non-standard HTTP status code.</summary>
+        [EnumMember(Value = "unknownError")]
         UnknownError,
+
         /// <summary>The operation was cancelled (typically by the user).</summary>
+        [EnumMember(Value = "cancelled")]
         Cancelled,
+
         /// <summary>Already exists (409).</summary>
+        [EnumMember(Value = "alreadyExists")]
         AlreadyExists,
+
         /// <summary>Operation was rejected because the system is not in a state required for the operation's</summary>
+        [EnumMember(Value = "failedPrecondition")]
         FailedPrecondition,
+
         /// <summary>The operation was aborted, typically due to a concurrency issue.</summary>
+        [EnumMember(Value = "aborted")]
         Aborted,
+
         /// <summary>Operation was attempted past the valid range.</summary>
+        [EnumMember(Value = "outOfRange")]
         OutOfRange,
+
         /// <summary>Unrecoverable data loss or corruption</summary>
+        [EnumMember(Value = "dataLoss")]
         DataLoss,
     }
 }

--- a/ContribSentry/Internals/Session.cs
+++ b/ContribSentry/Internals/Session.cs
@@ -33,11 +33,8 @@ namespace ContribSentry.Internals
         public bool? Init { get; private set; }
 
         /** The session state */
-        [JsonIgnore]
-        public ESessionState Status { get; set; }
-
         [JsonProperty("status")]
-        internal string _statusJson => Status.ConvertString();
+        public ESessionState Status { get; set; }
 
         /** The session sequence */
         [JsonIgnore]


### PR DESCRIPTION
Mono Json serialization ignores enums if they don't provide an EnumMember value.
this hotfix fixes the issue where Sessions lacked the State enum, not giving the correct session status nor session duration.