### PR TITLE
Ref/bump sentry

### DIFF
--- a/ContribSentry.AspNetCore.Tests/ContribSentry.AspNetCore.Tests.csproj
+++ b/ContribSentry.AspNetCore.Tests/ContribSentry.AspNetCore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="3.0.6" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.3.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/ContribSentry.AspNetCore.Tests/ContribSentry.AspNetCore.Tests.csproj
+++ b/ContribSentry.AspNetCore.Tests/ContribSentry.AspNetCore.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="2.1.4" />
+    <PackageReference Include="Sentry.AspNetCore" Version="3.0.6" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/ContribSentry.AspNetCore.Tests/ContribSentryNetCoreSdkIntegrationTests.cs
+++ b/ContribSentry.AspNetCore.Tests/ContribSentryNetCoreSdkIntegrationTests.cs
@@ -13,7 +13,7 @@ namespace ContribSentry.AspNetCore.Tests
             try
             {
                 var integration = new ContribSentryNetCoreSdkIntegration();
-                integration.Register(null,new SentryOptions());
+                integration.Register(null,new SentryOptions() { Dsn = DsnHelper.ValidDsnWithoutSecret });
                 Assert.True(ContribSentrySdk.IsEnabled);
                 Assert.True(ContribSentrySdk.IsTracingSdkEnabled);
                 Assert.Equal(typeof(ContribSentryTracingService), ContribSentrySdk.TracingService.GetType());

--- a/ContribSentry.AspNetCore/ContribSentry.AspNetCore.csproj
+++ b/ContribSentry.AspNetCore/ContribSentry.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Description>.Net Core Addon for ContribSentry</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/lucas-zimerman/sentry-dotnet-performance-addon</PackageProjectUrl>

--- a/ContribSentry.SessionTest/Cache/EnvelopeCacheTests.cs
+++ b/ContribSentry.SessionTest/Cache/EnvelopeCacheTests.cs
@@ -1,9 +1,7 @@
 ﻿using ContribSentry.Cache;
 using ContribSentry.Enums;
 using ContribSentry.Testing;
-using Sentry.Protocol;
-using System;
-using System.Collections.Generic;
+using Sentry;
 using System.IO;
 using Xunit;
 

--- a/ContribSentry.SessionTest/Initializer.cs
+++ b/ContribSentry.SessionTest/Initializer.cs
@@ -16,7 +16,7 @@ namespace SessionSdk.Test
             if (!ContribSentrySdk.IsEnabled)
             {
                 var integration = new ContribSentrySdkIntegration(new ContribSentryOptions() { GlobalSessionMode = true });
-                integration.Register(null, new SentryOptions() { Release = TestRelease, Environment = TestEnvironment, Dsn = new Dsn(Helpers.DsnHelper.ValidDsnWithoutSecret) });
+                integration.Register(null, new SentryOptions() { Release = TestRelease, Environment = TestEnvironment, Dsn = Helpers.DsnHelper.ValidDsnWithoutSecret });
             }
         }
     }

--- a/ContribSentry.SessionTest/Internals/SentryEnvelopeItemTest.cs
+++ b/ContribSentry.SessionTest/Internals/SentryEnvelopeItemTest.cs
@@ -1,6 +1,6 @@
 ﻿using ContribSentry.Enums;
 using ContribSentry.Internals;
-using Sentry.Protocol;
+using Sentry;
 using Xunit;
 
 namespace ContribSentry.SessionTest.Internals

--- a/ContribSentry.SessionTest/Internals/SentryEnvelopeTest.cs
+++ b/ContribSentry.SessionTest/Internals/SentryEnvelopeTest.cs
@@ -1,6 +1,6 @@
 ﻿using ContribSentry.Enums;
 using ContribSentry.Internals;
-using Sentry.Protocol;
+using Sentry;
 using System.IO;
 using Xunit;
 

--- a/ContribSentry.SessionTest/SessionTest.cs
+++ b/ContribSentry.SessionTest/SessionTest.cs
@@ -1,11 +1,9 @@
-using Moq;
-using Sentry.Protocol;
-using ContribSentry;
 using ContribSentry.Enums;
 using ContribSentry.Internals;
 using System;
 using System.Threading.Tasks;
 using Xunit;
+using Sentry;
 
 namespace SessionSdk.Test
 {

--- a/ContribSentry.Test/Mock/MockSessionService.cs
+++ b/ContribSentry.Test/Mock/MockSessionService.cs
@@ -1,6 +1,6 @@
 ﻿using ContribSentry.Extensibility;
 using ContribSentry.Interface;
-using Sentry.Protocol;
+using Sentry;
 
 namespace ContribSentry.Test.Mock
 {

--- a/ContribSentry.Testing/ContribSentry.Testing.csproj
+++ b/ContribSentry.Testing/ContribSentry.Testing.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Sentry" Version="3.0.6" />
+    <PackageReference Include="Sentry" Version="3.3.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/ContribSentry.Testing/ContribSentry.Testing.csproj
+++ b/ContribSentry.Testing/ContribSentry.Testing.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Sentry" Version="2.1.4" />
+    <PackageReference Include="Sentry" Version="3.0.6" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/ContribSentry/.Transaction/SentryTracingEvent.cs
+++ b/ContribSentry/.Transaction/SentryTracingEvent.cs
@@ -10,7 +10,7 @@ namespace ContribSentry
     {
 
         [JsonProperty("sentry_id")]
-        public SentryId EventId { get; }
+        public SentryId EventId { get; set; }
 
         [JsonProperty("type")]
         public string Type { get; private set; }
@@ -71,11 +71,14 @@ namespace ContribSentry
         [JsonProperty("extra")]
         public IReadOnlyDictionary<string, object> Extra { get; set; }
 
+        [JsonProperty("platform")]
+        public string Platform { get ; set ; }
 
         internal SentryTracingEvent(SentryTracing transactionEvent, bool hasError)
         {
             TransactionName = transactionEvent.Transaction;
             Type = "transaction";
+            EventId = SentryId.Create();
             Level = hasError ? SentryLevel.Error : SentryLevel.Info;
             Contexts.AddOrUpdate("trace", transactionEvent.Trace, (id, trace) => trace);
             Spans = transactionEvent.Spans;

--- a/ContribSentry/.Transaction/SentryTracingEvent.cs
+++ b/ContribSentry/.Transaction/SentryTracingEvent.cs
@@ -57,14 +57,21 @@ namespace ContribSentry
 
         public IReadOnlyList<string> Fingerprint { get ; set ; }
 
+        private List<Breadcrumb> _breadcrumbs { get; set; }
+
         [JsonProperty("breadcrumbs")]
-        public IReadOnlyCollection<Breadcrumb> Breadcrumbs { get; set; }
+        public IReadOnlyCollection<Breadcrumb> Breadcrumbs => _breadcrumbs;
+
+        private Dictionary<string, string> _tags { get; set; }
 
         [JsonProperty("tags")]
-        public IReadOnlyDictionary<string, string> Tags { get; set;}
+        public IReadOnlyDictionary<string, string> Tags => _tags;
+
+
+        private Dictionary<string, object> _extra;
 
         [JsonProperty("extra")]
-        public IReadOnlyDictionary<string, object> Extra { get; set; }
+        public IReadOnlyDictionary<string, object> Extra => _extra;
 
         [JsonProperty("platform")]
         public string Platform { get ; set ; }
@@ -84,27 +91,30 @@ namespace ContribSentry
             StartTimestamp = transactionEvent.StartTimestamp;
             Timestamp = DateTimeOffset.UtcNow;
             Sdk = ContribSentrySdk.Options.ContribSdk;
+            _extra = new Dictionary<string, object>();
+            _tags = new Dictionary<string, string>();
+            _breadcrumbs = new List<Breadcrumb>();
             this.SetExtras(transactionEvent.Extra);
         }
 
         public void AddBreadcrumb(Breadcrumb breadcrumb)
         {
-            throw new NotImplementedException();
+            _breadcrumbs.Add(breadcrumb);
         }
 
         public void SetTag(string key, string value)
         {
-            throw new NotImplementedException();
+            _tags[key] = value;
         }
 
         public void UnsetTag(string key)
         {
-            throw new NotImplementedException();
+            _tags.Remove(key);
         }
 
         public void SetExtra(string key, object value)
         {
-            throw new NotImplementedException();
+            _extra[key] = value;
         }
     }
 }

--- a/ContribSentry/.Transaction/SentryTracingEvent.cs
+++ b/ContribSentry/.Transaction/SentryTracingEvent.cs
@@ -6,8 +6,12 @@ using System.Collections.Generic;
 
 namespace ContribSentry
 {
-    public class SentryTracingEvent : SentryEvent
+    public class SentryTracingEvent : IEventLike
     {
+
+        [JsonProperty("sentry_id")]
+        public SentryId EventId { get; }
+
         [JsonProperty("type")]
         public string Type { get; private set; }
 
@@ -17,15 +21,86 @@ namespace ContribSentry
         [JsonProperty("start_timestamp")]
         public DateTimeOffset StartTimestamp { get; private set; }
 
+        [JsonProperty("level")]
+        public SentryLevel? Level { get; set; }
+
+        [JsonProperty("request")]
+        public Request Request { get ; set; }
+
+        private Contexts _contexts;
+
+        [JsonProperty("contexts")]
+        public Contexts Contexts
+        {
+            get 
+            {
+                if(_contexts is null)
+                {
+                    _contexts = new Contexts();
+                }
+                return _contexts;
+            }
+            set => _contexts = value;
+        }
+
+        [JsonProperty("users")]
+        public User User { get ; set ; }
+
+        [JsonProperty("release")]
+        public string Release { get ; set ; }
+
+        [JsonProperty("environment")]
+        public string Environment { get ; set ; }
+
+        [JsonProperty("transaction")]
+        public string TransactionName { get ; set ; }
+
+        [JsonProperty("sdk")]
+        public SdkVersion Sdk { get; set; }
+
+        [JsonProperty("fingerprint")]
+
+        public IReadOnlyList<string> Fingerprint { get ; set ; }
+
+        [JsonProperty("breadcrumbs")]
+        public IReadOnlyCollection<Breadcrumb> Breadcrumbs { get; set; }
+
+        [JsonProperty("tags")]
+        public IReadOnlyDictionary<string, string> Tags { get; set;}
+
+        [JsonProperty("extra")]
+        public IReadOnlyDictionary<string, object> Extra { get; set; }
+
+
         internal SentryTracingEvent(SentryTracing transactionEvent, bool hasError)
         {
-            Transaction = transactionEvent.Transaction;
+            TransactionName = transactionEvent.Transaction;
             Type = "transaction";
             Level = hasError ? SentryLevel.Error : SentryLevel.Info;
             Contexts.AddOrUpdate("trace", transactionEvent.Trace, (id, trace) => trace);
             Spans = transactionEvent.Spans;
             StartTimestamp = transactionEvent.StartTimestamp;
             this.SetExtras(transactionEvent.Extra);
+        }
+
+        public void AddBreadcrumb(Breadcrumb breadcrumb)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetTag(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void UnsetTag(string key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetExtra(string key, object value)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/ContribSentry/.Transaction/SentryTracingEvent.cs
+++ b/ContribSentry/.Transaction/SentryTracingEvent.cs
@@ -3,8 +3,6 @@ using Sentry;
 using ContribSentry.Interface;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Sentry.Protocol;
 
 namespace ContribSentry
 {

--- a/ContribSentry/.Transaction/SentryTracingEvent.cs
+++ b/ContribSentry/.Transaction/SentryTracingEvent.cs
@@ -90,7 +90,7 @@ namespace ContribSentry
             Spans = transactionEvent.Spans;
             StartTimestamp = transactionEvent.StartTimestamp;
             Timestamp = DateTimeOffset.UtcNow;
-            Sdk = ContribSentrySdk.Options.ContribSdk;
+            Sdk = ContribSentrySdk.Options?.ContribSdk;
             _extra = new Dictionary<string, object>();
             _tags = new Dictionary<string, string>();
             _breadcrumbs = new List<Breadcrumb>();

--- a/ContribSentry/.Transaction/SentryTracingExtensions.cs
+++ b/ContribSentry/.Transaction/SentryTracingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using ContribSentry.Internals;
 using Sentry;
+using System;
 using System.Collections.Generic;
 
 namespace ContribSentry.Transaction
@@ -24,14 +25,13 @@ namespace ContribSentry.Transaction
         {
             tracing.Breadcrumbs = sentryEvent.Breadcrumbs;
             tracing.Contexts = sentryEvent.Contexts;
+            tracing.Contexts.Trace.Operation = tracing.Trace.Op;
+            tracing.Contexts.Trace.TraceId = Guid.Parse(tracing.Trace.TraceId);
+            tracing.Contexts.Trace.SpanId = new SpanId(tracing.Trace.SpanId);
             tracing.Environment = sentryEvent.Environment;
             tracing.Extra = sentryEvent.Extra;
-            tracing.EventId = sentryEvent.EventId;
-            tracing.Fingerprint = sentryEvent.Fingerprint;
-            tracing.Level = sentryEvent.Level;
             tracing.Release = sentryEvent.Release;
             tracing.Request = sentryEvent.Request;
-            tracing.Sdk = sentryEvent.Sdk;
             tracing.Tags = sentryEvent.Tags;
             tracing.User = sentryEvent.User;
             tracing.Contexts.TryRemove(SentryTracing.TracingEventMessageKey, out _);

--- a/ContribSentry/.Transaction/SentryTracingExtensions.cs
+++ b/ContribSentry/.Transaction/SentryTracingExtensions.cs
@@ -20,12 +20,13 @@ namespace ContribSentry.Transaction
             }
         }
 
-        internal static void SetSentryEvent(this SentryTracingEvent tracing, IEventLike sentryEvent)
+        internal static void SetSentryEvent(this SentryTracingEvent tracing, SentryEvent sentryEvent)
         {
             tracing.Breadcrumbs = sentryEvent.Breadcrumbs;
             tracing.Contexts = sentryEvent.Contexts;
             tracing.Environment = sentryEvent.Environment;
             tracing.Extra = sentryEvent.Extra;
+            tracing.EventId = sentryEvent.EventId;
             tracing.Fingerprint = sentryEvent.Fingerprint;
             tracing.Level = sentryEvent.Level;
             tracing.Release = sentryEvent.Release;

--- a/ContribSentry/.Transaction/SentryTracingExtensions.cs
+++ b/ContribSentry/.Transaction/SentryTracingExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ContribSentry.Internals;
+using Sentry;
 using System.Collections.Generic;
 
 namespace ContribSentry.Transaction
@@ -17,6 +18,22 @@ namespace ContribSentry.Transaction
             {
                 _ = extra.AddOrUpdate(keyValuePair.Key, keyValuePair.Value, (s, o) => keyValuePair.Value);
             }
+        }
+
+        internal static void SetSentryEvent(this SentryTracingEvent tracing, IEventLike sentryEvent)
+        {
+            tracing.Breadcrumbs = sentryEvent.Breadcrumbs;
+            tracing.Contexts = sentryEvent.Contexts;
+            tracing.Environment = sentryEvent.Environment;
+            tracing.Extra = sentryEvent.Extra;
+            tracing.Fingerprint = sentryEvent.Fingerprint;
+            tracing.Level = sentryEvent.Level;
+            tracing.Release = sentryEvent.Release;
+            tracing.Request = sentryEvent.Request;
+            tracing.Sdk = sentryEvent.Sdk;
+            tracing.Tags = sentryEvent.Tags;
+            tracing.User = sentryEvent.User;
+            tracing.Contexts.TryRemove(SentryTracing.TracingEventMessageKey, out _);
         }
     }
 }

--- a/ContribSentry/.Transaction/SentryTracingExtensions.cs
+++ b/ContribSentry/.Transaction/SentryTracingExtensions.cs
@@ -23,16 +23,19 @@ namespace ContribSentry.Transaction
 
         internal static void SetSentryEvent(this SentryTracingEvent tracing, SentryEvent sentryEvent)
         {
-            tracing.Breadcrumbs = sentryEvent.Breadcrumbs;
+            foreach (var breadcrumb in sentryEvent.Breadcrumbs)
+            {
+                tracing.AddBreadcrumb(breadcrumb);
+            }
             tracing.Contexts = sentryEvent.Contexts;
             tracing.Contexts.Trace.Operation = tracing.Trace.Op;
             tracing.Contexts.Trace.TraceId = Guid.Parse(tracing.Trace.TraceId);
             tracing.Contexts.Trace.SpanId = new SpanId(tracing.Trace.SpanId);
             tracing.Environment = sentryEvent.Environment;
-            tracing.Extra = sentryEvent.Extra;
+            tracing.SetExtras(sentryEvent.Extra);
             tracing.Release = sentryEvent.Release;
             tracing.Request = sentryEvent.Request;
-            tracing.Tags = sentryEvent.Tags;
+            tracing.SetTags(sentryEvent.Tags);
             tracing.User = sentryEvent.User;
             tracing.Contexts.TryRemove(SentryTracing.TracingEventMessageKey, out _);
         }

--- a/ContribSentry/.Transaction/Trace.cs
+++ b/ContribSentry/.Transaction/Trace.cs
@@ -25,9 +25,9 @@ namespace ContribSentry
         public Trace()
         {
             var st = new StackTrace();
-            var sf = st.GetFrame(5);
+            var sf = st.GetFrame(5) ?? st.GetFrame(4) ?? st.GetFrame(3) ?? st.GetFrame(2) ?? st.GetFrame(1);
 
-            Op = sf.GetMethod().Name;
+            Op = sf?.GetMethod().Name;
             TraceId = Guid.NewGuid().LimitLength(100);
             SpanId = Guid.NewGuid().LimitLength();
 

--- a/ContribSentry/Cache/CachedSentryData.cs
+++ b/ContribSentry/Cache/CachedSentryData.cs
@@ -1,5 +1,5 @@
 ﻿using ContribSentry.Enums;
-using Sentry.Protocol;
+using Sentry;
 
 namespace ContribSentry.Cache
 {

--- a/ContribSentry/Cache/EnvelopeCache.cs
+++ b/ContribSentry/Cache/EnvelopeCache.cs
@@ -1,6 +1,6 @@
 ﻿using ContribSentry.Enums;
 using ContribSentry.Interface;
-using Sentry.Protocol;
+using Sentry;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/ContribSentry/ContribSentry.csproj
+++ b/ContribSentry/ContribSentry.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Sentry" Version="3.0.6" />
+    <PackageReference Include="Sentry" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ContribSentry/ContribSentry.csproj
+++ b/ContribSentry/ContribSentry.csproj
@@ -14,7 +14,7 @@
     <PackageId>ContribSentry</PackageId>
     <Product>ContribSentry.SessionSdk</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>3.1.7</Version>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -34,6 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Sentry" Version="3.3.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ContribSentry/ContribSentry.csproj
+++ b/ContribSentry/ContribSentry.csproj
@@ -33,8 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Sentry" Version="2.1.4" />
-    <PackageReference Include="Sentry.Protocol" Version="2.1.4" />
+    <PackageReference Include="Sentry" Version="3.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ContribSentry/ContribSentry.xml
+++ b/ContribSentry/ContribSentry.xml
@@ -62,7 +62,13 @@
             </summary>
             <param name="service">The Session service.</param>
         </member>
-        <!-- Badly formed XML comment ignored for member "M:ContribSentry.ContribSentryOptions.SetHasInternetCallback(System.Func{System.Boolean})" -->
+        <member name="M:ContribSentry.ContribSentryOptions.SetHasInternetCallback(System.Func{System.Boolean})">
+            <summary>
+            Used to know if ContribSentry should cache or not SentryEvents since<br/>.
+            it act as a middleware.
+            </summary>
+            <param name="hasInternet">the call that should return if the application has internet or not.</param>
+        </member>
         <member name="P:ContribSentry.ContribSentryOptions.TrackingIdMethod">
             <summary>
             Tries to Inject a custom TracingContext that another project requested.

--- a/ContribSentry/ContribSentry.xml
+++ b/ContribSentry/ContribSentry.xml
@@ -43,6 +43,11 @@
             <br>the given tracing event Id if the event is sent to Sentry</br>
             </summary>
         </member>
+        <member name="M:ContribSentry.ContribSentryOptions.DisableEventCaching">
+            <summary>
+            Disable the caching of Sentry events from ContribSentry.
+            </summary>
+        </member>
         <member name="M:ContribSentry.ContribSentryOptions.SetTracingService(ContribSentry.Interface.IContribSentryTracingService)">
             <summary>
             Allows to Inject a custom Tracing Service, must be set before SentrySdk.Init<br/>

--- a/ContribSentry/ContribSentry.xml
+++ b/ContribSentry/ContribSentry.xml
@@ -88,7 +88,7 @@
             Clears the project Data.
             </summary>
         </member>
-        <member name="M:ContribSentry.ContribSentrySdk.StartSession(Sentry.Protocol.User)">
+        <member name="M:ContribSentry.ContribSentrySdk.StartSession(Sentry.User)">
             <summary>
             Start new Session for the given user, if the user is not set, it'll use the DistinctId to distinct the user.
             </summary>
@@ -204,7 +204,7 @@
             <param name="options"></param>
             <param name="endConsumer">The internal Class used for sending Sessions to Sentry.</param>
         </member>
-        <member name="M:ContribSentry.Interface.IContribSentrySessionService.StartSession(Sentry.Protocol.User,System.String,System.String,System.String)">
+        <member name="M:ContribSentry.Interface.IContribSentrySessionService.StartSession(Sentry.User,System.String,System.String,System.String)">
             <summary>
             Start a new Session.<br/>
             Note: This function shouldn't be called by the developer.<br/>
@@ -257,6 +257,41 @@
             Invoke the user code on an isolated environment so that you can interact with Tracing from anywhere. 
             </summary>
             <returns>A task where the user code is running.</returns>
+        </member>
+        <member name="T:ContribSentry.Internals.ContribDsn">
+            <summary>
+            Based on Sentry .NET SDK's DSN code
+            </summary>
+        </member>
+        <member name="P:ContribSentry.Internals.ContribDsn.Source">
+            <summary>
+            Source DSN string.
+            </summary>
+        </member>
+        <member name="P:ContribSentry.Internals.ContribDsn.ProjectId">
+            <summary>
+            The project ID which the authenticated user is bound to.
+            </summary>
+        </member>
+        <member name="P:ContribSentry.Internals.ContribDsn.Path">
+            <summary>
+            An optional path of which Sentry is hosted.
+            </summary>
+        </member>
+        <member name="P:ContribSentry.Internals.ContribDsn.SecretKey">
+            <summary>
+            The optional secret key to authenticate the SDK.
+            </summary>
+        </member>
+        <member name="P:ContribSentry.Internals.ContribDsn.PublicKey">
+            <summary>
+            The required public key to authenticate the SDK.
+            </summary>
+        </member>
+        <member name="P:ContribSentry.Internals.ContribDsn.ApiBaseUri">
+            <summary>
+            Sentry API's base URI.
+            </summary>
         </member>
         <member name="P:ContribSentry.Internals.SentryEnvelopeHeader._eventIdString">
              <summary>

--- a/ContribSentry/ContribSentryOptions.cs
+++ b/ContribSentry/ContribSentryOptions.cs
@@ -28,7 +28,7 @@ namespace ContribSentry
             CacheEnabled = cacheEnable;
             CacheDirSize = CacheDirSizeDefault;
 
-            ContribSdk = new SdkVersion() { Name = "ContribSentry", Version = "3.0.1" };
+            ContribSdk = new SdkVersion() { Name = "ContribSentry", Version = "4.0.0" };
         }
 
         internal void ConsumeSentryOptions(SentryOptions options)

--- a/ContribSentry/ContribSentryOptions.cs
+++ b/ContribSentry/ContribSentryOptions.cs
@@ -25,6 +25,7 @@ namespace ContribSentry
             SessionEnabled = sessionEnable;
 
             CacheEnabled = cacheEnable;
+            EventCacheEnabled = cacheEnable;
             CacheDirSize = CacheDirSizeDefault;
 
             ContribSdk = new SdkVersion() { Name = "ContribSentry", Version = "4.0.0" };
@@ -54,6 +55,8 @@ namespace ContribSentry
         public bool TransactionEnabled { get; private set; }
         public bool SessionEnabled { get; private set; }
         public bool CacheEnabled { get; private set; }
+
+        internal bool EventCacheEnabled { get; private set; }
         /// <summary>
         /// True for single user applications like Apps, Otherwise, False.
         /// </summary>
@@ -93,6 +96,14 @@ namespace ContribSentry
         public IEventCache EventCache { get; private set; }
 
         /// <summary>
+        /// Disable the caching of Sentry events from ContribSentry.
+        /// </summary>
+        public void DisableEventCaching()
+        {
+            EventCacheEnabled = false;
+        }
+
+        /// <summary>
         /// Allows to Inject a custom Tracing Service, must be set before SentrySdk.Init<br/>
         /// is called.
         /// </summary>
@@ -113,7 +124,7 @@ namespace ContribSentry
         }
 
         /// <summary>
-        /// Used to know if ContribSentry should cache or not SentryEvents since<br/.
+        /// Used to know if ContribSentry should cache or not SentryEvents since<br/>.
         /// it act as a middleware.
         /// </summary>
         /// <param name="hasInternet">the call that should return if the application has internet or not.</param>

--- a/ContribSentry/ContribSentryOptions.cs
+++ b/ContribSentry/ContribSentryOptions.cs
@@ -2,7 +2,6 @@
 using ContribSentry.Internals;
 using Sentry;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 using System;
 
 namespace ContribSentry

--- a/ContribSentry/ContribSentryOptions.cs
+++ b/ContribSentry/ContribSentryOptions.cs
@@ -1,4 +1,5 @@
 ﻿using ContribSentry.Interface;
+using ContribSentry.Internals;
 using Sentry;
 using Sentry.Extensibility;
 using Sentry.Protocol;
@@ -32,7 +33,7 @@ namespace ContribSentry
 
         internal void ConsumeSentryOptions(SentryOptions options)
         {
-            Dsn = options.Dsn;
+            Dsn = ContribDsn.Parse(options.Dsn);
             Environment = options.Environment;
             Release = options.Release;
             BeforeSend = options.BeforeSend;
@@ -46,7 +47,7 @@ namespace ContribSentry
         }
 
         internal IDiagnosticLogger DiagnosticLogger { get; private set; }
-        internal Dsn Dsn { get; set; }
+        internal ContribDsn Dsn { get; set; }
         internal string Environment { get; set; }
         internal string Release { get; set; }
         internal bool IsEnabled => SessionEnabled || TransactionEnabled;

--- a/ContribSentry/ContribSentrySdk.cs
+++ b/ContribSentry/ContribSentrySdk.cs
@@ -1,10 +1,10 @@
-﻿using Sentry.Protocol;
-using ContribSentry.Enums;
+﻿using ContribSentry.Enums;
 using ContribSentry.Internals;
 using ContribSentry.Interface;
 using ContribSentry.Extensibility;
 using System;
 using ContribSentry.Cache;
+using Sentry;
 
 namespace ContribSentry
 {

--- a/ContribSentry/ContribSentrySdk.cs
+++ b/ContribSentry/ContribSentrySdk.cs
@@ -99,7 +99,7 @@ namespace ContribSentry
             TracingService = DisabledTracingService.Instance;
             EventCache = DisabledDiskCache.Instance;
             EnvelopeCache = DisabledEnvelopeCache.Instance;
-            Options.DiagnosticLogger?.Log(SentryLevel.Debug, $"ContribSentry Closed");
+            Options?.DiagnosticLogger?.Log(SentryLevel.Debug, $"ContribSentry Closed");
             CacheFileWorker = null;
             EndConsumer = null;
             Options = null;

--- a/ContribSentry/ContribSentrySdk.cs
+++ b/ContribSentry/ContribSentrySdk.cs
@@ -52,7 +52,10 @@ namespace ContribSentry
                 if (IsCacheEnabled)
                 {
                     Options.DiagnosticLogger?.Log(SentryLevel.Debug, $"ContribSentry Initializing Cache Service");
-                    EventCache = new DiskCache(Options);
+                    if (Options.EventCacheEnabled)
+                    {
+                        EventCache = new DiskCache(Options);
+                    }
                     EnvelopeCache = new EnvelopeCache(Options);
                     CacheFileWorker = new CacheFileWorker();
                     if (!CacheFileWorker.StartWorker())

--- a/ContribSentry/Extensibility/DisabledSessionService.cs
+++ b/ContribSentry/Extensibility/DisabledSessionService.cs
@@ -1,4 +1,5 @@
 ﻿using ContribSentry.Interface;
+using Sentry;
 using Sentry.Protocol;
 
 namespace ContribSentry.Extensibility
@@ -20,5 +21,6 @@ namespace ContribSentry.Extensibility
         public void CacheCurrentSesion() { }
 
         public void DeleteCachedCurrentSession() { }
+
     }
 }

--- a/ContribSentry/Extensions/DsnExtensions.cs
+++ b/ContribSentry/Extensions/DsnExtensions.cs
@@ -1,17 +1,18 @@
-﻿using Sentry;
+﻿using ContribSentry.Internals;
+using Sentry;
 
 namespace ContribSentry.Extensions
 {
     internal static class DsnExtensions
     {
-        internal static string GetEnvelopeUrl(this Dsn dsn)
+        internal static string GetEnvelopeUrl(this ContribDsn dsn)
         {
-            return $"{dsn.SentryUri.Scheme}://{dsn.SentryUri.Host}/api/{dsn.ProjectId}/envelope/?sentry_key={dsn.PublicKey}&sentry_version=7";
+            return $"{dsn.GetEnvelopeEndpointUri()}/?sentry_key={dsn.PublicKey}&sentry_version=7";
         }
 
-        internal static string GetEventUrl(this Dsn dsn)
+        internal static string GetEventUrl(this ContribDsn dsn)
         {
-            return $"{dsn.SentryUri.Scheme}://{dsn.SentryUri.Host}/api/{dsn.ProjectId}/store/?sentry_key={dsn.PublicKey}";
+            return $"{dsn.GetStoreEndpointUri()}/?sentry_key={dsn.PublicKey}";
         }
     }
 }

--- a/ContribSentry/Interface/IContribSentrySessionService.cs
+++ b/ContribSentry/Interface/IContribSentrySessionService.cs
@@ -1,4 +1,4 @@
-﻿using Sentry.Protocol;
+﻿using Sentry;
 
 namespace ContribSentry.Interface
 {

--- a/ContribSentry/Internals/CacheFileWorker.cs
+++ b/ContribSentry/Internals/CacheFileWorker.cs
@@ -1,7 +1,6 @@
 ﻿using ContribSentry.Extensibility;
-using Sentry.Protocol;
+using Sentry;
 using System;
-using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ContribSentry/Internals/ContribDsn.cs
+++ b/ContribSentry/Internals/ContribDsn.cs
@@ -1,0 +1,132 @@
+﻿using Sentry;
+using System;
+
+namespace ContribSentry.Internals
+{
+    /// <summary>
+    /// Based on Sentry .NET SDK's DSN code
+    /// </summary>
+    internal class ContribDsn
+    {
+        /// <summary>
+        /// Source DSN string.
+        /// </summary>
+        public string Source { get; }
+
+        /// <summary>
+        /// The project ID which the authenticated user is bound to.
+        /// </summary>
+        public string ProjectId { get; }
+
+        /// <summary>
+        /// An optional path of which Sentry is hosted.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// The optional secret key to authenticate the SDK.
+        /// </summary>
+        public string SecretKey { get; }
+
+        /// <summary>
+        /// The required public key to authenticate the SDK.
+        /// </summary>
+        public string PublicKey { get; }
+
+        /// <summary>
+        /// Sentry API's base URI.
+        /// </summary>
+        private Uri ApiBaseUri { get; }
+
+        private ContribDsn(
+            string source,
+            string projectId,
+            string path,
+            string secretKey,
+            string publicKey,
+            Uri apiBaseUri)
+        {
+            Source = source;
+            ProjectId = projectId;
+            Path = path;
+            SecretKey = secretKey;
+            PublicKey = publicKey;
+            ApiBaseUri = apiBaseUri;
+        }
+
+        public Uri GetStoreEndpointUri() => new Uri(ApiBaseUri, "store/");
+
+        public Uri GetEnvelopeEndpointUri() => new Uri(ApiBaseUri, "envelope/");
+
+        public override string ToString() => Source;
+
+        public static bool IsDisabled(string dsn) =>
+            Constants.DisableSdkDsnValue.Equals(dsn, StringComparison.OrdinalIgnoreCase);
+
+        public static ContribDsn Parse(string dsn)
+        {
+            var uri = new Uri(dsn);
+
+            // uri.UserInfo returns empty string instead of null when no user info data is provided
+            if (string.IsNullOrWhiteSpace(uri.UserInfo))
+            {
+                throw new ArgumentException("Invalid DSN: No public key provided.");
+            }
+
+            var keys = uri.UserInfo.Split(':');
+
+            var publicKey = keys[0];
+            if (string.IsNullOrWhiteSpace(publicKey))
+            {
+                throw new ArgumentException("Invalid DSN: No public key provided.");
+            }
+
+            var secretKey = keys.Length > 1
+                ? keys[1]
+                : null;
+
+            var path = uri.AbsolutePath.Substring(0, uri.AbsolutePath.LastIndexOf('/'));
+
+            var projectId = uri.AbsoluteUri.Substring(uri.AbsoluteUri.LastIndexOf('/') + 1);
+            if (string.IsNullOrWhiteSpace(projectId))
+            {
+                throw new ArgumentException("Invalid DSN: A Project Id is required.");
+            }
+
+            var apiBaseUri = new UriBuilder
+            {
+                Scheme = uri.Scheme,
+                Host = uri.DnsSafeHost,
+                Port = uri.Port,
+                Path = $"{path}/api/{projectId}/"
+            }.Uri;
+
+            return new ContribDsn(
+                dsn,
+                projectId,
+                path,
+                secretKey,
+                publicKey,
+                apiBaseUri
+            );
+        }
+
+        public static ContribDsn TryParse(string dsn)
+        {
+            if (string.IsNullOrWhiteSpace(dsn))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Parse(dsn);
+            }
+            catch
+            {
+                // Parse should not throw though!
+                return null;
+            }
+        }
+    }
+}

--- a/ContribSentry/Internals/ContribSentrySessionService.cs
+++ b/ContribSentry/Internals/ContribSentrySessionService.cs
@@ -1,8 +1,8 @@
 ﻿using ContribSentry.Cache;
 using ContribSentry.Enums;
 using ContribSentry.Interface;
+using Sentry;
 using Sentry.Extensibility;
-using Sentry.Protocol;
 using System;
 
 namespace ContribSentry.Internals

--- a/ContribSentry/Internals/DistinctiveId.cs
+++ b/ContribSentry/Internals/DistinctiveId.cs
@@ -1,4 +1,4 @@
-﻿using Sentry.Protocol;
+﻿using Sentry;
 using System;
 using System.Security.Cryptography;
 using System.Text;

--- a/ContribSentry/Internals/EndConsumerService.cs
+++ b/ContribSentry/Internals/EndConsumerService.cs
@@ -2,7 +2,7 @@
 using ContribSentry.Enums;
 using ContribSentry.Interface;
 using ContribSentry.Transport;
-using Sentry.Protocol;
+using Sentry;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/ContribSentry/Internals/EventProcessor/SentryTracingEventProcessor.cs
+++ b/ContribSentry/Internals/EventProcessor/SentryTracingEventProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Sentry;
+﻿using ContribSentry.Transaction;
+using Sentry;
 using Sentry.Extensibility;
 
 namespace ContribSentry.Internals.EventProcessor
@@ -7,10 +8,11 @@ namespace ContribSentry.Internals.EventProcessor
     {
         public SentryEvent Process(SentryEvent @event)
         {
-            if (@event is SentryTracingEvent performanceEvent)
+            if (@event.Message?.Message == SentryTracing.TracingEventMessageKey &&
+                @event.Contexts[SentryTracing.TracingEventMessageKey] is SentryTracingEvent tracing)
             {
-
-                ContribSentrySdk.EndConsumer.CaptureTracing(performanceEvent);
+                tracing.SetSentryEvent(@event);
+                ContribSentrySdk.EndConsumer.CaptureTracing(tracing);
                 return null;
             }
             return @event;

--- a/ContribSentry/Internals/SentryEnvelope.cs
+++ b/ContribSentry/Internals/SentryEnvelope.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Sentry.Protocol;
+using Sentry;
 using System.Collections.Generic;
 
 namespace ContribSentry.Internals

--- a/ContribSentry/Internals/SentryEnvelopeHeader.cs
+++ b/ContribSentry/Internals/SentryEnvelopeHeader.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Sentry.Protocol;
+using Sentry;
 using System;
 
 namespace ContribSentry.Internals

--- a/ContribSentry/Internals/SentryIdsonConverter.cs
+++ b/ContribSentry/Internals/SentryIdsonConverter.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using Sentry;
+using System;
+using Newtonsoft.Json;
+
+namespace ContribSentry.Internals
+{
+    internal class SentryIdJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(((SentryId)value).ToString());
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ContribSentry/Internals/SentryNewtonsoftByteConverter.cs
+++ b/ContribSentry/Internals/SentryNewtonsoftByteConverter.cs
@@ -1,0 +1,58 @@
+﻿using Sentry;
+using System.IO;
+using System.Text.Json;
+
+namespace ContribSentry.Internals
+{
+    internal class SentryNewtonsoftByteConverter
+    {
+        internal byte[] WriteSdkDataAsValue(SdkVersion version)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = false }))
+                {
+                    version.WriteTo(writer);
+                }
+                return ms.ToArray();
+            }
+        }
+
+        internal byte[] WriteContextsAsValue(Contexts contexts)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = false }))
+                {
+                    contexts.WriteTo(writer);
+                }
+                return ms.ToArray();
+            }
+        }
+
+        internal byte[] WriteRequestAsValue(Request request)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = false }))
+                {
+                    request.WriteTo(writer);
+                }
+                return ms.ToArray();
+            }
+        }
+
+        internal byte[] WriteUserAsValue(User user)
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new Utf8JsonWriter(ms, new JsonWriterOptions { Indented = false }))
+                {
+                    user.WriteTo(writer);
+                }
+                return ms.ToArray();
+            }
+        }
+
+    }
+}

--- a/ContribSentry/Internals/SentryNewtonsoftJsonConverter.cs
+++ b/ContribSentry/Internals/SentryNewtonsoftJsonConverter.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+using Sentry;
+using System;
+using System.IO;
+
+namespace ContribSentry.Internals
+{
+    class SentryNewtonsoftJsonConverter : JsonConverter
+    {
+        private SentryNewtonsoftByteConverter _translator = new SentryNewtonsoftByteConverter();
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is SdkVersion sdkVersion)
+            {
+                writer.WriteRawValue(System.Text.Encoding.UTF8.GetString(_translator.WriteSdkDataAsValue(sdkVersion)));
+            }
+            else if (value is Contexts contexts)
+            {
+                var v = System.Text.Encoding.UTF8.GetString(_translator.WriteContextsAsValue(contexts));
+                writer.WriteRawValue(v);
+            }
+            else if (value is Request request)
+            {
+                    writer.WriteRawValue(System.Text.Encoding.UTF8.GetString(_translator.WriteRequestAsValue(request)));
+            }
+            else if (value is User user)
+            {
+                writer.WriteRawValue(System.Text.Encoding.UTF8.GetString(_translator.WriteUserAsValue(user)));
+            }
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/ContribSentry/Internals/Session.cs
+++ b/ContribSentry/Internals/Session.cs
@@ -1,8 +1,8 @@
 ﻿using Newtonsoft.Json;
-using Sentry.Protocol;
 using ContribSentry.Enums;
 using ContribSentry.Extensions;
 using System;
+using Sentry;
 
 namespace ContribSentry.Internals
 {

--- a/ContribSentry/Serializer.cs
+++ b/ContribSentry/Serializer.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Sentry;
 using Newtonsoft.Json.Converters;
 using ContribSentry.Extensions;
+using Newtonsoft.Json.Serialization;
 
 namespace ContribSentry
 {
@@ -23,6 +24,7 @@ namespace ContribSentry
             jsonSettings = new JsonSerializerSettings()
             {
                 ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 DateFormatHandling = DateFormatHandling.IsoDateFormat,
                 DateTimeZoneHandling = DateTimeZoneHandling.Utc,
                 Formatting = Formatting.None,

--- a/ContribSentry/Transport/HttpTransport.cs
+++ b/ContribSentry/Transport/HttpTransport.cs
@@ -1,6 +1,6 @@
 ﻿using ContribSentry.Cache;
 using ContribSentry.Extensions;
-using Sentry.Protocol;
+using Sentry;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;

--- a/DotNetCoreConsoleSession/Program.cs
+++ b/DotNetCoreConsoleSession/Program.cs
@@ -14,7 +14,7 @@ namespace DotNetCoreConsoleSession
             var sentryOptions = new SentryOptions()
             {
                 Environment = "development",
-                Dsn = new Dsn("https://1b869b04656740518013bc2e9d5753b7@o188313.ingest.sentry.io/5458365"),
+                Dsn = "https://1b869b04656740518013bc2e9d5753b7@o188313.ingest.sentry.io/5458365",
                 Debug = true,
                 Release = $"ContribSentrySamples X"
             };

--- a/Testing/Cache/EnvelopeCacheTests.cs
+++ b/Testing/Cache/EnvelopeCacheTests.cs
@@ -1,7 +1,7 @@
 ﻿using ContribSentry.Cache;
 using ContribSentry.Enums;
 using ContribSentry.Testing;
-using Sentry.Protocol;
+using Sentry;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Testing/Internals/SentryEnvelopeTests.cs
+++ b/Testing/Internals/SentryEnvelopeTests.cs
@@ -1,8 +1,5 @@
 ﻿using ContribSentry.Internals;
-using Sentry.Protocol;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using Sentry;
 using Xunit;
 
 namespace ContribSentry.TracingTest.Internals


### PR DESCRIPTION
 This is a huge update that will make ContribSentry compatible with the latest Sentry.NET SDK but also Sentry.Xamarin and Sentry.Xamarin.Forms.

Expect breaking changes from Sentry.NET SDK 3.0.0 or higher and the breaking changes can be found at the Changelog of Sentry.NET SDK.

Some additional code like ContribDsn came straight forward from Sentry.NET SDK mostly because the code that was previously used is now internal.

The Transaction flow has changed since SentryEvent is now sealed. The new flow is done in the following way:
* Create a mockup event.
* Add ContribSentry Tracing on the created event as an additional context.
* Capture the event.
* Instead of checking if the event type we now check if the event has the Tracing context.

Other changes came from the JsonSerialization since Sentry dropped Newtonsoft, some tooling had to be made to correctly serialize the event parameters.

